### PR TITLE
Fix: Resolve type error in PlaceDetailPage

### DIFF
--- a/src/app/(main)/place/[placeId]/page.tsx
+++ b/src/app/(main)/place/[placeId]/page.tsx
@@ -400,7 +400,10 @@ export default function PlaceDetailPage({ params }: PlaceDetailPageProps) {
                 </h2>
                 <HorizontalScrollBar
                   title="" // Title is handled by the h2 above
-                  cardData={relatedPlaces} // relatedPlaces are PlaceDetails[], compatible with LocationDetail[]
+                  cardData={relatedPlaces.map(place => ({
+                    ...place,
+                    vicinity: place.vicinity || "",
+                  }))} // relatedPlaces are PlaceDetails[], compatible with LocationDetail[]
                   images={relatedPlaces.map(p => p.photo_urls?.[0] || DEFAULT_IMAGE_URL)}
                   scrollButton={{ route: "" as any, loading: false }} // Effectively hides "See all"
                   handleNavigation={() => {}} // Dummy function as "See all" is hidden


### PR DESCRIPTION
The 'HorizontalScrollBar' component expects 'cardData' with a 'vicinity' property of type 'string'. The 'relatedPlaces' data, of type 'PlaceDetails[]', had 'vicinity' as 'string | undefined'.

This commit modifies 'src/app/(main)/place/[placeId]/page.tsx' to map over 'relatedPlaces' before passing it to 'HorizontalScrollBar'. If 'place.vicinity' is undefined, it now defaults to an empty string (""), ensuring compatibility with the expected 'LocationDetail[]' type and resolving the build error.